### PR TITLE
Fix: Update navigation links in index.html to be relative paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
   </head>
   <body>
     <nav class="main-nav">
-      <a href="/index.html" class="nav-brand">SynapseAI</a>
+      <a href="./index.html" class="nav-brand">SynapseAI</a>
       <div class="nav-links">
-        <a href="/index.html" class="nav-link active" id="home-link">Home</a>
-        <a href="/about.html" class="nav-link">About</a>
-        <a href="/contact.html" class="nav-link">Contact</a>
+        <a href="./index.html" class="nav-link active" id="home-link">Home</a>
+        <a href="./about.html" class="nav-link">About</a>
+        <a href="./contact.html" class="nav-link">Contact</a>
       </div>
     </nav>
     <!-- This div is the target for our tsParticles background -->


### PR DESCRIPTION
This change modifies the href attributes in the main navigation menu to use relative paths (e.g., `./about.html` instead of `/about.html`).

This ensures that the links work correctly when the site is deployed to a subdirectory, such as on GitHub Pages, by resolving correctly under `https://username.github.io/repository-name/`.