### PR TITLE
Feat: Configure explicit HTML inputs for Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,15 @@
 import { defineConfig } from "vite";
+import { resolve } from "path";
 
 export default defineConfig({
   base: "/ai-drug-discovery-page/", // IMPORTANT: This must match your repository name!
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        about: resolve(__dirname, "about.html"),
+        contact: resolve(__dirname, "contact.html"),
+      },
+    },
+  },
 });


### PR DESCRIPTION
Updated `vite.config.js` to include `index.html`, `about.html`, and `contact.html` in `build.rollupOptions.input`.

This ensures that all necessary HTML pages are processed by Vite and included in the `dist` directory, which should resolve issues with these pages not being found when deployed to GitHub Pages.